### PR TITLE
Feature: Optimized Lerp

### DIFF
--- a/common/config.coffee
+++ b/common/config.coffee
@@ -11,7 +11,9 @@ config =
     port: 8089
     prefix: '/pong'
   client:
-    interpolate: true  # interpolate or use naive approach
+    interpolate: true
+    regularLinearInterpolate: false
+    optimizedLinearInterpolate: true
     interpLatency: 100 # interpolation latency interval
   update:
     # milliseconds

--- a/common/game.coffee
+++ b/common/game.coffee
@@ -266,15 +266,12 @@ class ClientGame extends Game
 
       # if statements that check for how we should interpolate
       if !@conf.client.interpolate
-        alert "none"
         this.noInterpolation currentTime
         this.collisionCheck timeDelta
       else if @conf.client.optimizedLinearInterpolate
-        alert "opt"
         this.optimizedLinearInterpolation currentTime
         this.collisionCheck timeDelta
       else if @conf.client.regularLinearInterpolate
-        alert "reg"
         this.regularLinearInterpolation currentTime
         this.collisionCheck timeDelta
 


### PR DESCRIPTION
## Problem

There are two different types of linear interpolation that can be used, one imprecise method which does not guarantee v is v1 when t is 1 due to floating-point arithmetic error (but it can be used when the hardware has a native fused multiply-add instruction) and an optimized method that does guarantee v is v1 when t is t1  (but it can't be used when the hardware has a native fused multiply-add instruction).

## Solution
Cleaned up the code and added the optimized linear interpolation (lerp)

## Steps to Test
1. Test the naive approach by playing with interpolate: false, regularLinearInterpolate: false, and optimizedLinearInterpolate: false
2. Test the unoptimized lerp approach by playing with interpolate: true, regularLinearInterpolate: true, and optimizedLinearInterpolate: false
3. Test the optimized lerp approach by playing with interpolate: true, regularLinearInterpolate: false, and optimizedLinearInterpolate: true


